### PR TITLE
[BLE] Splitting Provision section into Provision and Verify

### DIFF
--- a/feature/ble/src/main/java/no/nordicsemi/android/wifi/provisioner/ble/repository/ProvisionerResourceRepository.kt
+++ b/feature/ble/src/main/java/no/nordicsemi/android/wifi/provisioner/ble/repository/ProvisionerResourceRepository.kt
@@ -90,7 +90,7 @@ class ProvisionerResourceRepository(
         return runTask { repository.forgetConfig() }
     }
 
-    suspend fun release() {
+    fun release() {
         repository.release()
     }
 

--- a/feature/ble/src/main/java/no/nordicsemi/android/wifi/provisioner/ble/sections/ProvisioningSection.kt
+++ b/feature/ble/src/main/java/no/nordicsemi/android/wifi/provisioner/ble/sections/ProvisioningSection.kt
@@ -31,13 +31,13 @@ fun ProvisioningSection(
         icon = Icons.Outlined.NetworkCheck,
         title = stringResource(id = R.string.section_provision),
         state = when {
-            state.isProvisioningComplete() -> WizardStepState.COMPLETED
+            state.isValidationInProgress() || state.isProvisioningComplete() -> WizardStepState.COMPLETED
             state.isProvisioningAvailable() || state.isProvisioningInProgress() -> WizardStepState.CURRENT
             else -> WizardStepState.INACTIVE
         },
         decor = when {
             state.isProvisioningInProgress() -> WizardStepAction.ProgressIndicator
-            state.isProvisioningAvailable() || state.isProvisioningComplete() ->
+            state.isProvisioningAvailable() || state.isValidationInProgress() || state.isProvisioningComplete() ->
                 WizardStepAction.Action(
                     text = stringResource(id = R.string.action_provision),
                     onClick = { onEvent(OnProvisionClickEvent) },
@@ -53,64 +53,16 @@ fun ProvisioningSection(
         },
         showVerticalDivider = false,
     ) {
-        ProgressItem(
-            text = state.provisioningStatus.getText(WifiConnectionStateDomain.Authentication),
-            status = state.provisioningStatus.getStatus(WifiConnectionStateDomain.Authentication),
-            iconRightPadding = 24.dp,
-        )
-        ProgressItem(
-            text = state.provisioningStatus.getText(WifiConnectionStateDomain.Association),
-            status = state.provisioningStatus.getStatus(WifiConnectionStateDomain.Association),
-            iconRightPadding = 24.dp,
-        )
-        ProgressItem(
-            text = state.provisioningStatus.getText(WifiConnectionStateDomain.ObtainingIp),
-            status = state.provisioningStatus.getStatus(WifiConnectionStateDomain.ObtainingIp),
-            iconRightPadding = 24.dp,
-        )
-        ProgressItem(
-            text = state.provisioningStatus.getText(WifiConnectionStateDomain.Connected),
-            status = state.provisioningStatus.getStatus(WifiConnectionStateDomain.Connected),
-            iconRightPadding = 24.dp,
-        )
-    }
-}
-
-private fun Resource<WifiConnectionStateDomain>?.getStatus(state: WifiConnectionStateDomain): ProgressItemStatus {
-    return when (this) {
-        is Loading -> when (state) {
-            WifiConnectionStateDomain.Authentication -> ProgressItemStatus.WORKING
+        val progress = when (state.provisioningStatus) {
+            is Loading -> ProgressItemStatus.WORKING
+            is Success -> ProgressItemStatus.SUCCESS
+            is Error -> ProgressItemStatus.ERROR
             else -> ProgressItemStatus.DISABLED
         }
-
-        is Success -> when {
-            data is WifiConnectionStateDomain.ConnectionFailed && state == WifiConnectionStateDomain.Connected -> ProgressItemStatus.ERROR
-            state.id == data.id + 1 -> ProgressItemStatus.WORKING
-            state.id <= data.id -> ProgressItemStatus.SUCCESS
-            else -> ProgressItemStatus.DISABLED
-        }
-
-        is Error -> ProgressItemStatus.ERROR
-
-        else -> ProgressItemStatus.DISABLED
-    }
-}
-
-@Composable
-private fun Resource<WifiConnectionStateDomain>?.getText(state: WifiConnectionStateDomain): String {
-    val status = getStatus(state)
-    return when (this) {
-        is Loading, null -> state.toDisplayString(status)
-        is Success -> {
-            val data = data
-            when {
-                data is WifiConnectionStateDomain.ConnectionFailed && state == WifiConnectionStateDomain.Connected -> data.reason?.toDisplayString() ?: "Connection failed"
-                else -> state.toDisplayString(status)
-            }
-        }
-        is Error -> when (state) {
-            WifiConnectionStateDomain.Connected -> error.message ?: stringResource(id = RUI.string.unknown_error)
-            else -> state.toDisplayString(status)
-        }
+        ProgressItem(
+            text = WifiConnectionStateDomain.Disconnected.toDisplayString(progress),
+            status = progress,
+            iconRightPadding = 24.dp,
+        )
     }
 }

--- a/feature/ble/src/main/java/no/nordicsemi/android/wifi/provisioner/ble/sections/StatusSection.kt
+++ b/feature/ble/src/main/java/no/nordicsemi/android/wifi/provisioner/ble/sections/StatusSection.kt
@@ -1,0 +1,103 @@
+package no.nordicsemi.android.wifi.provisioner.ble.sections
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Verified
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import no.nordicsemi.android.common.theme.view.ProgressItem
+import no.nordicsemi.android.common.theme.view.ProgressItemStatus
+import no.nordicsemi.android.common.theme.view.WizardStepAction
+import no.nordicsemi.android.common.theme.view.WizardStepComponent
+import no.nordicsemi.android.common.theme.view.WizardStepState
+import no.nordicsemi.android.wifi.provisioner.ble.view.BleViewEntity
+import no.nordicsemi.android.wifi.provisioner.ble.view.toDisplayString
+import no.nordicsemi.android.wifi.provisioner.feature.ble.R
+import no.nordicsemi.kotlin.wifi.provisioner.domain.WifiConnectionStateDomain
+import no.nordicsemi.kotlin.wifi.provisioner.domain.resource.Error
+import no.nordicsemi.kotlin.wifi.provisioner.domain.resource.Loading
+import no.nordicsemi.kotlin.wifi.provisioner.domain.resource.Resource
+import no.nordicsemi.kotlin.wifi.provisioner.domain.resource.Success
+import no.nordicsemi.kotlin.wifi.provisioner.feature.common.event.ProvisioningViewEvent
+import no.nordicsemi.android.wifi.provisioner.ui.R as RUI
+
+@Composable
+fun StatusSection(
+    state: BleViewEntity,
+    onEvent: (ProvisioningViewEvent) -> Unit,
+) {
+    WizardStepComponent(
+        icon = Icons.Default.Verified,
+        title = stringResource(id = R.string.section_status),
+        state = when {
+            state.isProvisioningComplete() -> WizardStepState.COMPLETED
+            state.isValidationInProgress() -> WizardStepState.CURRENT
+            else -> WizardStepState.INACTIVE
+        },
+        decor = when {
+            state.isValidationInProgress() -> WizardStepAction.ProgressIndicator
+            else -> null
+        },
+        showVerticalDivider = false,
+    ) {
+        ProgressItem(
+            text = state.provisioningStatus.getText(WifiConnectionStateDomain.Authentication),
+            status = state.provisioningStatus.getStatus(WifiConnectionStateDomain.Authentication),
+            iconRightPadding = 24.dp,
+        )
+        ProgressItem(
+            text = state.provisioningStatus.getText(WifiConnectionStateDomain.Association),
+            status = state.provisioningStatus.getStatus(WifiConnectionStateDomain.Association),
+            iconRightPadding = 24.dp,
+        )
+        ProgressItem(
+            text = state.provisioningStatus.getText(WifiConnectionStateDomain.ObtainingIp),
+            status = state.provisioningStatus.getStatus(WifiConnectionStateDomain.ObtainingIp),
+            iconRightPadding = 24.dp,
+        )
+        ProgressItem(
+            text = state.provisioningStatus.getText(WifiConnectionStateDomain.Connected),
+            status = state.provisioningStatus.getStatus(WifiConnectionStateDomain.Connected),
+            iconRightPadding = 24.dp,
+        )
+    }
+}
+
+private fun Resource<WifiConnectionStateDomain>?.getStatus(state: WifiConnectionStateDomain): ProgressItemStatus {
+    return when (this) {
+        is Loading -> when (state) {
+            WifiConnectionStateDomain.Disconnected -> ProgressItemStatus.WORKING
+            else -> ProgressItemStatus.DISABLED
+        }
+
+        is Success -> when {
+            data is WifiConnectionStateDomain.ConnectionFailed && state == WifiConnectionStateDomain.Connected -> ProgressItemStatus.ERROR
+            state.id == data.id + 1 -> ProgressItemStatus.WORKING
+            state.id <= data.id -> ProgressItemStatus.SUCCESS
+            else -> ProgressItemStatus.DISABLED
+        }
+
+        is Error -> ProgressItemStatus.ERROR
+
+        else -> ProgressItemStatus.DISABLED
+    }
+}
+
+@Composable
+private fun Resource<WifiConnectionStateDomain>?.getText(state: WifiConnectionStateDomain): String {
+    val status = getStatus(state)
+    return when (this) {
+        is Loading, null -> state.toDisplayString(status)
+        is Success -> {
+            val data = data
+            when {
+                data is WifiConnectionStateDomain.ConnectionFailed && state == WifiConnectionStateDomain.Connected -> data.reason?.toDisplayString() ?: "Connection failed"
+                else -> state.toDisplayString(status)
+            }
+        }
+        is Error -> when (state) {
+            WifiConnectionStateDomain.Connected -> error.message ?: stringResource(id = RUI.string.unknown_error)
+            else -> state.toDisplayString(status)
+        }
+    }
+}

--- a/feature/ble/src/main/java/no/nordicsemi/android/wifi/provisioner/ble/view/BleProvisioningScreen.kt
+++ b/feature/ble/src/main/java/no/nordicsemi/android/wifi/provisioner/ble/view/BleProvisioningScreen.kt
@@ -58,6 +58,7 @@ import no.nordicsemi.android.wifi.provisioner.ble.sections.DeviceSelectionSectio
 import no.nordicsemi.android.wifi.provisioner.ble.sections.NetworkStatusSection
 import no.nordicsemi.android.wifi.provisioner.ble.sections.ProvisioningSection
 import no.nordicsemi.android.wifi.provisioner.ble.sections.SecuritySection
+import no.nordicsemi.android.wifi.provisioner.ble.sections.StatusSection
 import no.nordicsemi.android.wifi.provisioner.ble.viewmodel.BleViewModel
 import no.nordicsemi.android.wifi.provisioner.feature.ble.R
 import no.nordicsemi.android.wifi.provisioner.ui.PasswordDialog
@@ -112,6 +113,7 @@ fun BleProvisioningScreen() {
                         NetworkStatusSection(state = state, onEvent = onEvent)
                         SecuritySection(state = state, onEvent = onEvent)
                         ProvisioningSection(state = state, onEvent = onEvent)
+                        StatusSection(state = state, onEvent = onEvent)
                     }
                 }
             }

--- a/feature/ble/src/main/java/no/nordicsemi/android/wifi/provisioner/ble/view/BleViewEntity.kt
+++ b/feature/ble/src/main/java/no/nordicsemi/android/wifi/provisioner/ble/view/BleViewEntity.kt
@@ -59,7 +59,8 @@ data class BleViewEntity(
         return device != null && version == null
                 || version is Loading
                 || status is Loading
-                || provisioningStatus is Loading
+                || isProvisioningInProgress()
+                || isValidationInProgress()
                 || unprovisioningStatus is Loading
     }
 
@@ -79,8 +80,13 @@ data class BleViewEntity(
     }
 
     override fun isProvisioningInProgress(): Boolean {
+        return isConnected && provisioningStatus is Loading
+    }
+
+    override fun isValidationInProgress(): Boolean {
         return isConnected
                 && provisioningStatus != null
+                && provisioningStatus !is Loading
                 && !isProvisioningComplete()
                 && !hasProvisioningFailed()
     }

--- a/feature/ble/src/main/java/no/nordicsemi/android/wifi/provisioner/ble/view/UiMapper.kt
+++ b/feature/ble/src/main/java/no/nordicsemi/android/wifi/provisioner/ble/view/UiMapper.kt
@@ -43,6 +43,11 @@ import no.nordicsemi.kotlin.wifi.provisioner.domain.WifiConnectionStateDomain
 fun WifiConnectionStateDomain?.toDisplayString(
     state: ProgressItemStatus = ProgressItemStatus.SUCCESS
 ) = when (this) {
+        WifiConnectionStateDomain.Disconnected -> when (state) {
+            ProgressItemStatus.WORKING -> R.string.wifi_status_provisioning
+            ProgressItemStatus.SUCCESS -> R.string.wifi_status_provisioned
+            else -> R.string.wifi_status_provision
+        }
         WifiConnectionStateDomain.Authentication -> when (state) {
             ProgressItemStatus.WORKING -> R.string.wifi_status_authenticating
             ProgressItemStatus.SUCCESS -> R.string.wifi_status_authenticated

--- a/feature/ble/src/main/java/no/nordicsemi/android/wifi/provisioner/ble/viewmodel/BleViewModel.kt
+++ b/feature/ble/src/main/java/no/nordicsemi/android/wifi/provisioner/ble/viewmodel/BleViewModel.kt
@@ -58,12 +58,9 @@ import no.nordicsemi.android.wifi.provisioner.ble.view.BleWifiScannerDestination
 import no.nordicsemi.android.wifi.provisioner.ble.view.OnUnprovisionEvent
 import no.nordicsemi.android.wifi.provisioner.ble.view.OnVolatileMemoryChangedEvent
 import no.nordicsemi.android.wifi.provisioner.ble.view.OpenLoggerEvent
-import no.nordicsemi.kotlin.wifi.provisioner.domain.DeviceStatusDomain
-import no.nordicsemi.kotlin.wifi.provisioner.domain.WifiConnectionStateDomain
 import no.nordicsemi.kotlin.wifi.provisioner.domain.resource.Loading
 import no.nordicsemi.kotlin.wifi.provisioner.domain.resource.Success
 import no.nordicsemi.kotlin.wifi.provisioner.feature.common.WifiData
-import no.nordicsemi.kotlin.wifi.provisioner.feature.common.event.OnFinishedEvent
 import no.nordicsemi.kotlin.wifi.provisioner.feature.common.event.OnHidePasswordDialog
 import no.nordicsemi.kotlin.wifi.provisioner.feature.common.event.OnPasswordSelectedEvent
 import no.nordicsemi.kotlin.wifi.provisioner.feature.common.event.OnProvisionClickEvent

--- a/feature/ble/src/main/java/no/nordicsemi/android/wifi/provisioner/ble/viewmodel/BleViewModel.kt
+++ b/feature/ble/src/main/java/no/nordicsemi/android/wifi/provisioner/ble/viewmodel/BleViewModel.kt
@@ -101,12 +101,16 @@ class BleViewModel @Inject constructor(
             .launchIn(viewModelScope)
     }
 
+    override fun onCleared() {
+        release()
+        super.onCleared()
+    }
+
     fun onEvent(event: ProvisioningViewEvent) {
         if (event != OpenLoggerEvent) {
             cancelPendingJobs()
         }
         when (event) {
-            OnFinishedEvent -> finish()
             is OnPasswordSelectedEvent -> onPasswordSelected(event.password)
             OnSelectDeviceClickEvent -> requestBluetoothDevice()
             OnReconnectClickEvent -> (_state.value.device as? RealServerDevice)?.let { installBluetoothDevice(it) }
@@ -160,19 +164,8 @@ class BleViewModel @Inject constructor(
         _state.value = _state.value.copy(showPasswordDialog = false)
     }
 
-    private fun finish() {
-        viewModelScope.launch {
-            release()
-            _state.value = BleViewEntity()
-        }
-    }
-
-    private suspend fun release() {
-        try {
-            repository.release()
-        } catch (e: Exception) {
-            e.printStackTrace()
-        }
+    private fun release() {
+        repository.release()
     }
 
     private fun requestBluetoothDevice() {

--- a/feature/ble/src/main/res/values/strings.xml
+++ b/feature/ble/src/main/res/values/strings.xml
@@ -44,6 +44,7 @@
     <string name="section_network">Wi-Fi</string>
     <string name="section_security">Security</string>
     <string name="section_provision">Provision</string>
+    <string name="section_status">Verify</string>
 
     <string name="connect">Connect</string>
     <string name="connecting">Pairing…</string>
@@ -58,6 +59,9 @@
     <string name="set_password">Set Wi-Fi password</string>
     <string name="password_encoded">Password: ********</string>
 
+    <string name="wifi_status_provision">Send Wi-Fi credentials</string>
+    <string name="wifi_status_provisioning">Sending Wi-Fi credentials…</string>
+    <string name="wifi_status_provisioned">Wi-Fi credentials sent</string>
     <string name="wifi_status_authenticate">Authenticate</string>
     <string name="wifi_status_authenticating">Authenticating…</string>
     <string name="wifi_status_authenticated">Authenticated</string>

--- a/feature/common/src/main/java/no/nordicsemi/kotlin/wifi/provisioner/feature/common/event/ViewEvent.kt
+++ b/feature/common/src/main/java/no/nordicsemi/kotlin/wifi/provisioner/feature/common/event/ViewEvent.kt
@@ -36,8 +36,6 @@ data object OnReconnectClickEvent : ProvisioningViewEvent
 
 data object OnSelectDeviceClickEvent : ProvisioningViewEvent
 
-data object OnFinishedEvent : ProvisioningViewEvent
-
 data object OnProvisionNextDeviceEvent : ProvisioningViewEvent
 
 data object OnSelectWifiEvent : ProvisioningViewEvent

--- a/feature/common/src/main/java/no/nordicsemi/kotlin/wifi/provisioner/feature/common/view/ViewEntity.kt
+++ b/feature/common/src/main/java/no/nordicsemi/kotlin/wifi/provisioner/feature/common/view/ViewEntity.kt
@@ -25,6 +25,8 @@ interface ViewEntity {
 
     fun isProvisioningInProgress(): Boolean
 
+    fun isValidationInProgress(): Boolean
+
     /**
      * Check if the provisioning has finished successfully.
      */

--- a/feature/softap/src/main/java/no/nordicsemi/android/wifi/provisioner/softap/view/SoftApScreen.kt
+++ b/feature/softap/src/main/java/no/nordicsemi/android/wifi/provisioner/softap/view/SoftApScreen.kt
@@ -395,11 +395,10 @@ private fun Provisioning(
         ProgressItem(
             text = when {
                 isProvisioningRequested && provisioningState == WizardStepState.CURRENT -> stringResource(
-                    R.string.provisioning_device_to_your_network
+                    R.string.wifi_status_provisioning
                 )
-                provisioningState == WizardStepState.COMPLETED -> stringResource(R.string.provisioning_completed)
-                provisioningState == WizardStepState.INACTIVE -> stringResource(R.string.provisioning_rationale)
-                else -> stringResource(R.string.provisioning_rationale)
+                provisioningState == WizardStepState.COMPLETED -> stringResource(R.string.wifi_status_provisioned)
+                else -> stringResource(R.string.wifi_status_provision)
             },
             status = when {
                 isProvisioningRequested && provisioningState == WizardStepState.CURRENT -> ProgressItemStatus.WORKING
@@ -437,10 +436,9 @@ private fun Verify(
         ProgressItem(
             text = when {
                 isVerificationRequested && verificationState == WizardStepState.CURRENT ->
-                    stringResource(R.string.locating_provisioned_device)
-                verificationState == WizardStepState.CURRENT -> stringResource(R.string.optional_verification_rationale)
-                verificationState == WizardStepState.COMPLETED -> stringResource(R.string.verification_completed)
-                else -> stringResource(R.string.optional_verification_rationale)
+                    stringResource(R.string.wifi_status_verifying)
+                verificationState == WizardStepState.COMPLETED -> stringResource(R.string.wifi_status_verified)
+                else -> stringResource(R.string.wifi_status_verify)
             },
             status = when {
                 isVerificationRequested && verificationState == WizardStepState.CURRENT -> ProgressItemStatus.WORKING

--- a/feature/softap/src/main/res/values/strings.xml
+++ b/feature/softap/src/main/res/values/strings.xml
@@ -34,12 +34,13 @@
     <string name="select_wifi">Select Access Point</string>
     <string name="set_wifi_passphrase">Set Wi-Fi password</string>
     <string name="set_passphrase_value">Password: ********</string>
-    <string name="provisioning_device_to_your_network">Sending Wi-Fi credentials…</string>
-    <string name="provisioning_completed">Wi-Fi credentials sent</string>
-    <string name="provisioning_rationale">Send Wi-Fi credentials</string>
-    <string name="optional_verification_rationale">Verify provisioning state (optional)</string>
-    <string name="locating_provisioned_device">Locating provisioned device…</string>
-    <string name="verification_completed">Verification completed</string>
+
+    <string name="wifi_status_provision">Send Wi-Fi credentials</string>
+    <string name="wifi_status_provisioning">Sending Wi-Fi credentials…</string>
+    <string name="wifi_status_provisioned">Wi-Fi credentials sent</string>
+    <string name="wifi_status_verify">Verify provisioning state (optional)</string>
+    <string name="wifi_status_verifying">Locating provisioned device…</string>
+    <string name="wifi_status_verified">Verification completed</string>
 
     <string name="please_enable_wi_fi">Please enable Wi-Fi!</string>
     <string name="failed_to_bind_to_network">Failed to bind to network!</string>

--- a/lib/ble/build.gradle.kts
+++ b/lib/ble/build.gradle.kts
@@ -42,6 +42,7 @@ android {
 dependencies {
     api(project(":lib:domain"))
 
+    implementation(libs.slf4j)
     implementation(libs.nordic.ble.ktx)
 }
 

--- a/lib/ble/src/main/java/no/nordicsemi/android/wifi/provisioner/ble/ProvisionerRepository.kt
+++ b/lib/ble/src/main/java/no/nordicsemi/android/wifi/provisioner/ble/ProvisionerRepository.kt
@@ -124,7 +124,7 @@ interface ProvisionerRepository {
     /**
      * Closes connection with the DK.
      */
-    suspend fun release()
+    fun release()
 
     companion object {
         @SuppressLint("StaticFieldLeak")

--- a/lib/ble/src/main/java/no/nordicsemi/android/wifi/provisioner/ble/ProvisionerRepositoryImpl.kt
+++ b/lib/ble/src/main/java/no/nordicsemi/android/wifi/provisioner/ble/ProvisionerRepositoryImpl.kt
@@ -85,7 +85,7 @@ class ProvisionerRepositoryImpl internal constructor(
         manager?.forgetWifi()
     }
 
-    override suspend fun release() {
+    override fun release() {
         manager?.release()
         manager = null
     }

--- a/lib/ble/src/main/java/no/nordicsemi/android/wifi/provisioner/ble/internal/ProvisionerBleManager.kt
+++ b/lib/ble/src/main/java/no/nordicsemi/android/wifi/provisioner/ble/internal/ProvisionerBleManager.kt
@@ -108,9 +108,9 @@ internal class ProvisionerBleManager(
     }
 
     @SuppressLint("MissingPermission")
-    suspend fun release() {
-        removeBond().suspend()
-        disconnect().suspend()
+    fun release() {
+        removeBond().enqueue()
+        disconnect().enqueue()
     }
 
     @SuppressLint("WrongConstant")

--- a/lib/ble/src/main/java/no/nordicsemi/android/wifi/provisioner/ble/internal/ProvisionerBleManager.kt
+++ b/lib/ble/src/main/java/no/nordicsemi/android/wifi/provisioner/ble/internal/ProvisionerBleManager.kt
@@ -153,10 +153,10 @@ internal class ProvisionerBleManager(
     }
 
     suspend fun getVersion(): Info = withTimeout(TIMEOUT_MILLIS) {
-        val response =
-            readCharacteristic(versionCharacteristic).suspendForValidResponse<ByteArrayReadResponse>().value
+        val response = readCharacteristic(versionCharacteristic)
+            .suspendForValidResponse<ByteArrayReadResponse>()
 
-        Info.ADAPTER.decode(response)
+        Info.ADAPTER.decode(response.value)
     }
 
     suspend fun getStatus(): DeviceStatus = withTimeout(TIMEOUT_MILLIS) {
@@ -172,9 +172,7 @@ internal class ProvisionerBleManager(
             )
             .suspendForValidResponse<ByteArrayReadResponse>()
 
-        verifyResponseSuccess(response.value)
-
-        Response.ADAPTER.decode(response.value).device_status!!
+        verifyResponseSuccess(response.value).device_status!!
     }
 
     fun startScan() = callbackFlow {
@@ -276,12 +274,12 @@ internal class ProvisionerBleManager(
         verifyResponseSuccess(response.value)
     }
 
-    private fun verifyResponseSuccess(response: ByteArray) {
-        val status = Response.ADAPTER.decode(response).status
-        if (status != Status.SUCCESS) {
-            throw createResponseError(status)
+    private fun verifyResponseSuccess(bytes: ByteArray): Response =
+        Response.ADAPTER.decode(bytes).also {
+            if (it.status != Status.SUCCESS) {
+                throw createResponseError(it.status)
+            }
         }
-    }
 
     private fun createResponseError(status: Status?): Exception {
         val errorCode = when (status) {

--- a/lib/softap/build.gradle.kts
+++ b/lib/softap/build.gradle.kts
@@ -14,6 +14,8 @@ dependencies {
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.annotation)
 
+    implementation(libs.slf4j)
+
     implementation(libs.retrofit.core)
     implementation(libs.retrofit.converter.gson)
     implementation(libs.retrofit.converter.scalars)
@@ -21,7 +23,6 @@ dependencies {
     implementation(libs.okhttp)
     implementation(libs.okhttp.logging)
     implementation("com.squareup.okhttp3:okhttp-tls:5.0.0-alpha.12")
-    implementation("org.slf4j:slf4j-api:1.7.36") // TODO replace with libs
 }
 
 wire {


### PR DESCRIPTION
This PR fixes:
* Provision section was split into 2:
   * Provision (just sending provisioning request)
   * Verify (getting connection updates)
* Disconnection when leaving BLE screen
* Logging BLE requests and responses
* Unified state texts in BLE and SoftAP