### PR TITLE
Remove NFC hardware restriction from manifest.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -33,6 +33,10 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-feature
+        android:name="android.hardware.nfc"
+        android:required="false" />
+
     <application
         android:name="no.nordicsemi.android.wifi.provisioner.WifiProvisionerApplication"
         android:allowBackup="false"


### PR DESCRIPTION
This PR changes the manifest file, which restricts the application's visibility on Google Play to devices equipped with NFC hardware.