### PR TITLE
Add an option to pass custom UUIDs for provisioning

### DIFF
--- a/lib/ble/src/main/java/no/nordicsemi/android/wifi/provisioner/ble/ProvisionerRepository.kt
+++ b/lib/ble/src/main/java/no/nordicsemi/android/wifi/provisioner/ble/ProvisionerRepository.kt
@@ -135,6 +135,14 @@ interface ProvisionerRepository {
          * Creates new instance of [ProvisionerRepository]
          *
          * @param context the application context
+         * @param provisioningServiceUuidOverride
+         * optional provisioning service UUID to use instead of the default one
+         * @param versionCharacteristicUuidOverride
+         * optional version characteristic UUID to use instead of the default one
+         * @param controlPointCharacteristicUuidOverride
+         * optional control point characteristic UUID to use instead of the default one
+         * @param dataOutCharacteristicUuidOverride
+         * optional data out characteristic UUID to use instead of the default one
          */
         fun newInstance(
             context: Context,

--- a/lib/ble/src/main/java/no/nordicsemi/android/wifi/provisioner/ble/ProvisionerRepository.kt
+++ b/lib/ble/src/main/java/no/nordicsemi/android/wifi/provisioner/ble/ProvisionerRepository.kt
@@ -43,6 +43,7 @@ import no.nordicsemi.android.wifi.provisioner.ble.internal.ConnectionStatus
 import no.nordicsemi.android.wifi.provisioner.ble.internal.ResponseErrorException
 import no.nordicsemi.android.wifi.provisioner.ble.internal.NotificationTimeoutException
 import kotlinx.coroutines.flow.Flow
+import java.util.UUID
 
 /**
  * A class responsible for establishing connection and maintaining communication with a nRF 7 device.
@@ -135,9 +136,21 @@ interface ProvisionerRepository {
          *
          * @param context the application context
          */
-        fun newInstance(context: Context): ProvisionerRepository {
+        fun newInstance(
+            context: Context,
+            provisioningServiceUuidOverride: UUID? = null,
+            versionCharacteristicUuidOverride: UUID? = null,
+            controlPointCharacteristicUuidOverride: UUID? = null,
+            dataOutCharacteristicUuidOverride: UUID? = null
+        ): ProvisionerRepository {
             val app = context.applicationContext
-            val newInstance = instance ?: ProvisionerFactory.createRepository(app)
+            val newInstance = instance ?: ProvisionerFactory.createRepository(
+                app,
+                provisioningServiceUuidOverride,
+                versionCharacteristicUuidOverride,
+                controlPointCharacteristicUuidOverride,
+                dataOutCharacteristicUuidOverride
+            )
             instance = newInstance
             return newInstance
         }

--- a/lib/ble/src/main/java/no/nordicsemi/android/wifi/provisioner/ble/ProvisionerRepositoryImpl.kt
+++ b/lib/ble/src/main/java/no/nordicsemi/android/wifi/provisioner/ble/ProvisionerRepositoryImpl.kt
@@ -45,16 +45,27 @@ import no.nordicsemi.android.wifi.provisioner.ble.domain.toApi
 import no.nordicsemi.android.wifi.provisioner.ble.domain.toDomain
 import no.nordicsemi.android.wifi.provisioner.ble.internal.ConnectionStatus
 import no.nordicsemi.android.wifi.provisioner.ble.internal.ProvisionerBleManager
+import java.util.UUID
 
 class ProvisionerRepositoryImpl internal constructor(
-    private val context: Context
+    private val context: Context,
+    private val provisioningServiceUuidOverride: UUID?,
+    private val versionCharacteristicUuidOverride: UUID?,
+    private val controlPointCharacteristicUuidOverride: UUID?,
+    private val dataOutCharacteristicUuidOverride: UUID?
 ) : ProvisionerRepository {
 
     private var manager: ProvisionerBleManager? = null
 
     @SuppressLint("MissingPermission")
     override suspend fun start(device: BluetoothDevice): Flow<ConnectionStatus> {
-        manager = ProvisionerFactory.createBleManager(context)
+        manager = ProvisionerFactory.createBleManager(
+            context,
+            provisioningServiceUuidOverride,
+            versionCharacteristicUuidOverride,
+            controlPointCharacteristicUuidOverride,
+            dataOutCharacteristicUuidOverride
+        )
         return manager!!.start(device)
     }
 
@@ -94,11 +105,35 @@ class ProvisionerRepositoryImpl internal constructor(
 
 internal object ProvisionerFactory {
 
-    fun createRepository(context: Context): ProvisionerRepositoryImpl {
-        return ProvisionerRepositoryImpl(context)
+    fun createRepository(
+        context: Context,
+        provisioningServiceUuidOverride: UUID?,
+        versionCharacteristicUuidOverride: UUID?,
+        controlPointCharacteristicUuidOverride: UUID?,
+        dataOutCharacteristicUuidOverride: UUID?
+    ): ProvisionerRepositoryImpl {
+        return ProvisionerRepositoryImpl(
+            context,
+            provisioningServiceUuidOverride,
+            versionCharacteristicUuidOverride,
+            controlPointCharacteristicUuidOverride,
+            dataOutCharacteristicUuidOverride
+        )
     }
 
-    fun createBleManager(context: Context): ProvisionerBleManager {
-        return ProvisionerBleManager(context)
+    fun createBleManager(
+        context: Context,
+        provisioningServiceUuidOverride: UUID?,
+        versionCharacteristicUuidOverride: UUID?,
+        controlPointCharacteristicUuidOverride: UUID?,
+        dataOutCharacteristicUuidOverride: UUID?
+    ): ProvisionerBleManager {
+        return ProvisionerBleManager(
+            context,
+            provisioningServiceUuidOverride,
+            versionCharacteristicUuidOverride,
+            controlPointCharacteristicUuidOverride,
+            dataOutCharacteristicUuidOverride
+        )
     }
 }

--- a/lib/ble/src/main/java/no/nordicsemi/android/wifi/provisioner/ble/internal/ProvisionerBleManager.kt
+++ b/lib/ble/src/main/java/no/nordicsemi/android/wifi/provisioner/ble/internal/ProvisionerBleManager.kt
@@ -73,6 +73,10 @@ private const val TIMEOUT_MILLIS = 60_000L
 
 internal class ProvisionerBleManager(
     context: Context,
+    private val provisioningServiceUuidOverride: UUID?,
+    private val versionCharacteristicUuidOverride: UUID?,
+    private val controlPointCharacteristicUuidOverride: UUID?,
+    private val dataOutCharacteristicUuidOverride: UUID?
 ) : BleManager(context) {
     private val logger = LoggerFactory.getLogger(ProvisionerBleManager::class.java)
 
@@ -131,12 +135,20 @@ internal class ProvisionerBleManager(
     }
 
     override fun isRequiredServiceSupported(gatt: BluetoothGatt): Boolean {
-        val service: BluetoothGattService? = gatt.getService(PROVISIONING_SERVICE_UUID)
+        val service: BluetoothGattService? = gatt.getService(
+            provisioningServiceUuidOverride ?: PROVISIONING_SERVICE_UUID
+        )
         if (service != null) {
-            versionCharacteristic = service.getCharacteristic(VERSION_CHARACTERISTIC_UUID)
+            versionCharacteristic = service.getCharacteristic(
+                versionCharacteristicUuidOverride ?: VERSION_CHARACTERISTIC_UUID
+            )
             controlPointCharacteristic =
-                service.getCharacteristic(CONTROL_POINT_CHARACTERISTIC_UUID)
-            dataOutCharacteristic = service.getCharacteristic(DATA_OUT_CHARACTERISTIC_UUID)
+                service.getCharacteristic(
+                    controlPointCharacteristicUuidOverride ?: CONTROL_POINT_CHARACTERISTIC_UUID
+                )
+            dataOutCharacteristic = service.getCharacteristic(
+                dataOutCharacteristicUuidOverride ?: DATA_OUT_CHARACTERISTIC_UUID
+            )
         }
         var writeRequest: Boolean
 


### PR DESCRIPTION
Adds the option to pass custom UUIDs to `newInstance` in case the nRF device doesn't use the default UUIDs by Nordic.

With that approach a project I'm working on would be greatly simplified and since the parameters are optional, we'd still used the default UUIDs, which makes this a backwards-compatible enhancement.

This fixes https://github.com/NordicSemiconductor/Android-nRF-Wi-Fi-Provisioner/issues/31